### PR TITLE
Allow to pass write options

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,13 +82,14 @@ Usage:
 #### writeCSV
 
 ```ts
-writeCSV(path: string, data: Record<string, unknown>[] | string)
+writeCSV(path: string, data: Record<string, unknown>[] | string, options?: Deno.WriteFileOptions)
 ```
 
 Args:
 
 * **path**: path to a local CSV file
 * **data**: string or object array to store
+* **options**: [options](https://doc.deno.land/builtin/stable#Deno.WriteFileOptions) for writing the CSV file
 
 Usage:
 
@@ -122,14 +123,14 @@ const text = await readTXT('./path/to/file.txt')
 #### writeTXT
 
 ```ts
-writeTXT(path: string, text: string): void
+writeTXT(path: string, text: string, options?: Deno.WriteFileOptions): void
 ```
 
 Args:
 
 * **path**: path to a local TXT file
 * **text**: text to write to file
-
+* **options**: [options](https://doc.deno.land/builtin/stable#Deno.WriteFileOptions) for writing the TXT file
 
 Usage:
 

--- a/src/csv.ts
+++ b/src/csv.ts
@@ -15,9 +15,9 @@ export async function readCSV(path: string, options?: ParseOptions): Promise<Rec
     return content as Record<string, unknown>[]
 }
 
-export async function writeCSV(path: string, data: Record<string, unknown>[] | string) {
+export async function writeCSV(path: string, data: Record<string, unknown>[] | string, options?: Deno.WriteFileOptions) {
     if (typeof data === 'string') {
-        await Deno.writeTextFile(path, data);
+        await Deno.writeTextFile(path, data, options);
         return
     }
 
@@ -25,5 +25,5 @@ export async function writeCSV(path: string, data: Record<string, unknown>[] | s
     // we have to stringify the data with a row header
     const dataString = await stringify(data as DataItem[], headers)
 
-    await Deno.writeTextFile(path, dataString);
+    await Deno.writeTextFile(path, dataString, options);
 }

--- a/src/txt.ts
+++ b/src/txt.ts
@@ -3,6 +3,6 @@ export async function readTXT(path: string) {
     return text
 }
   
-export async function writeTXT(path: string, text: string) {
-    await Deno.writeTextFile(path, text)
+export async function writeTXT(path: string, text: string, options?: Deno.WriteFileOptions) {
+    await Deno.writeTextFile(path, text, options)
 }

--- a/tests/csv-test.ts
+++ b/tests/csv-test.ts
@@ -34,3 +34,26 @@ Deno.test("writes a csv file", async () => {
 
     assertArrayIncludes(csv, [{ age: "70", name: "Rick" }]);
 })
+Deno.test("appends to a csv file", async () => {
+    const data = [
+        { 
+            age: 70,
+            name: 'Rick'
+        },
+        {
+            age: 14,
+            name: 'Smith'
+        }
+    ]
+    await writeCSV(csvWritePath, data)
+    const data2 = [
+        {
+            age: 42,
+            name: 'Jodi'
+        }
+    ]
+    await writeCSV(csvWritePath, data2, { append: true })
+    const csv = await readCSV(csvWritePath)
+    assertArrayIncludes(csv, [{ age: "70", name: "Rick" }])
+    assertArrayIncludes(csv, [{ age: "42", name: "Jodi" }])
+})

--- a/tests/csv-test.ts
+++ b/tests/csv-test.ts
@@ -34,6 +34,7 @@ Deno.test("writes a csv file", async () => {
 
     assertArrayIncludes(csv, [{ age: "70", name: "Rick" }]);
 })
+
 Deno.test("appends to a csv file", async () => {
     const data = [
         { 

--- a/tests/txt-test.ts
+++ b/tests/txt-test.ts
@@ -18,3 +18,14 @@ Deno.test("writes a txt file", async () => {
 
     assertStringIncludes(txt, content);
 })
+
+Deno.test("appends to a txt file", async () => {
+    const content = 'Write to a file'
+    const content2 = 'Append to a file'
+    await writeTXT(jsonWritePath, content)
+    await writeTXT(jsonWritePath, content2, { append: true })
+    const txt = await readTXT(jsonWritePath)
+
+    assertStringIncludes(txt, content);
+    assertStringIncludes(txt, content2);
+})


### PR DESCRIPTION
Allow to pass [write options](https://doc.deno.land/builtin/stable#Deno.WriteFileOptions) when useful, which mostly allow to use the append mode.